### PR TITLE
TaskCard styling small screen

### DIFF
--- a/client/src/components/Tasks/CompletedTaskItem.tsx
+++ b/client/src/components/Tasks/CompletedTaskItem.tsx
@@ -16,15 +16,17 @@ const CompletedTaskItem: React.FC<CompletedTaskItemProps> = ({
   room,
 }: CompletedTaskItemProps) => {
   return (
-    <div className="bg-gray-50 shadow-sm sm:rounded-lg my-5 ring-1 ring-black/5">
-      <div className="px-3 py-4 sm:px-6 sm:py-4">
-        <div className="flex flex-col space-y-4 sm:flex-row sm:justify-between sm:items-center sm:space-y-1">
+    <div className="bg-gray-50 shadow-sm rounded-lg my-5 ring-1 ring-black/5">
+      <div className="px-6 py-4">
+        <div className="flex flex-row justify-between items-center">
           {/* Left section: Task details */}
           <div className="flex flex-col space-y-1">
-            <h2 className="text-lg font-semibold text-gray-500 line-through">
+            <h2 className="text-lg font-semibold text-gray-500 line-through truncate">
               {taskName}
             </h2>
-            <p className="text-sm text-gray-500 line-through">{room}</p>
+            <p className="text-sm text-gray-500 line-through truncate">
+              {room}
+            </p>
           </div>
 
           {/* Task Actions (Right Side) */}

--- a/client/src/components/Tasks/TaskItem.tsx
+++ b/client/src/components/Tasks/TaskItem.tsx
@@ -2,16 +2,14 @@ import React from "react";
 import TaskActions from "./TaskActions";
 import dueInFormatting from "../../utils/dueInFormatting";
 
-// Define props type
 interface TaskItemProps {
   taskName: string;
   dueDate: number;
   taskID: string;
   room: string;
-  children?: React.ReactNode; // This allows passing a TaskActions component
+  children?: React.ReactNode;
 }
 
-// TaskCard Component
 const TaskItem: React.FC<TaskItemProps> = ({
   taskName,
   dueDate,
@@ -19,13 +17,15 @@ const TaskItem: React.FC<TaskItemProps> = ({
   room,
 }: TaskItemProps) => {
   return (
-    <div className="bg-white shadow-sm sm:rounded-lg my-5 ring-1 ring-black/5">
-      <div className="px-3 py-4 sm:px-6 sm:py-4">
-        <div className="flex flex-col space-y-4 sm:flex-row sm:justify-between sm:items-center sm:space-y-1">
+    <div className="bg-white shadow-sm rounded-lg my-5 ring-1 ring-black/5">
+      <div className="px-6 py-4">
+        <div className="flex flex-row justify-between items-center">
           {/* Left section: Task details */}
           <div className="flex flex-col space-y-1">
-            <h2 className="text-lg font-semibold text-gray-800">{taskName}</h2>
-            <p className="text-sm text-gray-500">{room}</p>
+            <h2 className="text-lg font-semibold text-gray-800 truncate">
+              {taskName}
+            </h2>
+            <p className="text-sm text-gray-500 truncate">{room}</p>
             {dueInFormatting(dueDate)}
           </div>
 

--- a/client/src/utils/dueInFormatting.tsx
+++ b/client/src/utils/dueInFormatting.tsx
@@ -15,7 +15,7 @@ export default function dueInFormatting(dueIn: number) {
   if (daysDifference === 0) {
     return (
       <>
-        <div className="flex items-center text-sm text-blue-500">
+        <div className="flex items-center text-sm text-blue-500 truncate">
           <CalendarDaysIcon className={"h-4 w-4 mr-2"} />
           <p>Due today</p>
         </div>
@@ -24,7 +24,7 @@ export default function dueInFormatting(dueIn: number) {
   } else if (daysDifference === 1) {
     return (
       <>
-        <div className="flex items-center text-sm text-green-700">
+        <div className="flex items-center text-sm text-green-700 truncate">
           <CalendarDaysIcon className={"h-4 w-4 mr-2"} />
           <p>Due tomorrow</p>
         </div>
@@ -33,7 +33,7 @@ export default function dueInFormatting(dueIn: number) {
   } else if (daysDifference > 1) {
     return (
       <>
-        <div className="flex items-center text-sm text-green-700">
+        <div className="flex items-center text-sm text-green-700 truncate">
           <CalendarDaysIcon className={"h-4 w-4 mr-2"} />
           <p>Due in {daysDifference} days</p>
         </div>


### PR DESCRIPTION
- Adjusted padding and border-radius changes for sm breakpoints (removed unnecessary classes)
- Added truncate to text elements to handle very narrow windows
- Removed flex-row to force the dropdown onto the next line at the sm breakpoint